### PR TITLE
アニメの各話ごとに視聴を記録する

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import time
 
 CONFIG_FILE_PATH = 'config'
 RECORD_FILE_PATH = 'record'
-MAX_NUM_RECORDS = 50
+MAX_NUM_RECORDS = 3
 
 
 def log(message: str) -> None:
@@ -134,12 +134,12 @@ def is_already_posted(activity: Activity) -> bool:
     with open(RECORD_FILE_PATH, 'r') as record_file:
         posted_activities = record_file.read().split('\n')
 
-    return f'{activity.work_id} {activity.status}' in posted_activities
+    return f'{activity.work_id} {activity.status if activity.status else activity.work_episode_id}' in posted_activities
 
 
 def update_record(activity: Activity) -> None:
     with open(RECORD_FILE_PATH, 'a') as record_file:
-        print(activity.work_id, activity.status, file=record_file)
+        print(activity.work_id, activity.status if activity.status else activity.work_episode_id, file=record_file)
 
     recorded_activities: list[str]
 

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import time
 
 CONFIG_FILE_PATH = 'config'
 RECORD_FILE_PATH = 'record'
-MAX_NUM_RECORDS = 3
+MAX_NUM_RECORDS = 50
 
 
 def log(message: str) -> None:

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ def log(message: str) -> None:
 class Activity:
     work_id: int
     work_title: str
-    work_subtitle: str
     work_episode_id: int
     work_episode_number: str
     work_episode_title: str

--- a/main.py
+++ b/main.py
@@ -21,7 +21,6 @@ class Activity:
     work_episode_id: int
     work_episode_number: str
     work_episode_title: str
-    work_episode_rating_state: str
     work_episode_comment: str
     work_season: str
     work_url: str = ''
@@ -37,7 +36,7 @@ def get_activities(user_id: int, access_token: str, num_fetch: int) -> list[Acti
         'sort_id': 'desc',
         'fields': 'work.id,work.title,work.season_name_text,' \
                   'action,status.kind,' \
-                  'record.comment,record.rating_state,' \
+                  'record.comment,' \
                   'episode.number_text,episode.title,episode.id',
     }
     resp = requests.get('https://api.annict.com/v1/activities', params)
@@ -64,7 +63,6 @@ def get_activities(user_id: int, access_token: str, num_fetch: int) -> list[Acti
             activity.work_episode_id = episode_info['id']
 
             activity.work_episode_comment = record_info['comment']
-            activity.work_episode_rating_state = record_info['rating_state']
 
             activity.work_url = f'https://annict.com/works/{activity.work_id}/episodes/{activity.work_episode_id}'
 
@@ -120,10 +118,12 @@ def create_messages(activities: list[Activity]) -> list[str]:
                 continue
         elif activity.action == 'create_record':
             result.append(f'「{activity.work_title}」{activity.work_episode_number} {activity.work_episode_title} を観ました。')
-            # TODO: result.append(f'[{activity.work_episode_rating_state}]{activity.work_episode_comment}') などで感想コメントも出力する
 
         if activity.work_url != '':
             result[-1] += f'\n{activity.work_url}'
+
+        if activity.action == 'create_record' and activity.work_episode_comment != '':
+            result[-1] += f'\n----------------------------------------------------\n{activity.work_episode_comment}'
 
     return result
 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ def get_activities(user_id: int, access_token: str, num_fetch: int) -> list[Acti
             episode_info = activity_info['episode']
 
             activity.work_id = work_info['id']
+            activity.work_title = work_info['title']
 
             activity.work_episode_title = episode_info['title']
             activity.work_episode_number = episode_info['number_text']
@@ -118,7 +119,7 @@ def create_messages(activities: list[Activity]) -> list[str]:
                 result.append('')
                 continue
         elif activity.action == 'create_record':
-            result.append(f'「{activity.work_episode_title}」{activity.work_episode_number} {activity.work_episode_title}を観ました。')
+            result.append(f'「{activity.work_title}」{activity.work_episode_number} {activity.work_episode_title} を観ました。')
             # TODO: result.append(f'[{activity.work_episode_rating_state}]{activity.work_episode_comment}') などで感想コメントも出力する
 
         if activity.work_url != '':


### PR DESCRIPTION
# アニメの各話ごとに視聴を記録する

現状ではアニメ作品単位で

- 「見てる」
- 「見た」
- 「見たい」
- 「一時中断している」
- 「視聴中止した」

のこれら5つの視聴状況の記録のみが転送されている。

これらアニメの作品という単位だけでなく、各話ごとの視聴の記録も同様に Discord に転送させるようにしたい。
視聴の記録とあわせて、感想を記述していたらそれも一緒に転送する。